### PR TITLE
enable Google Circle to Search

### DIFF
--- a/super.img/product/etc/build.prop
+++ b/super.img/product/etc/build.prop
@@ -100,5 +100,7 @@ ro.com.google.gmsversion=14_202310
 setupwizard.feature.enable_quick_start_flow=true
 wlan.wfd.hdcp=disable
 wifi.interface=wlan0
+ro.com.google.cdb.spa1=bsxasm1
+ro.bbt.support.circle2search=true
 # end of file
 

--- a/super.img/product/etc/sysconfig/google_searcle.xml
+++ b/super.img/product/etc/sysconfig/google_searcle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <!-- This is for update Searcle for Samsung from play store -->
+    <feature name="com.samsung.feature.EXPERIENCE_CTS" />
+</config>
+


### PR DESCRIPTION
This should be enough but I have seen that for some devices I had to spoof a supported device props in Google app